### PR TITLE
Use bounding rect instead of innerHeight to get more precise height.

### DIFF
--- a/cosmos.js
+++ b/cosmos.js
@@ -3,8 +3,8 @@ var pxs = [];
 var rint = 50;
 $(document).ready(function() {
     var windowSize = function() {
-        WIDTH = $('.star-net').innerWidth();
-        HEIGHT = $('.star-net').innerHeight();
+        WIDTH = $('.star-net')[0].getBoundingClientRect().width;
+        HEIGHT = $('.star-net')[0].getBoundingClientRect().height;
         canvas = $('#galaxy');
         canvas.attr('width', WIDTH).attr('height', HEIGHT);
     };


### PR DESCRIPTION
This works around a bug on chrome for windows, which shows artifacts when a canvas is larger than it's container.
